### PR TITLE
Rename extension to 'percona_pg_telemetry'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -32,8 +32,8 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version of PostgreSQL and pg_percona_telemetry are you running?
-      placeholder: PostgreSQL 16.2, pg_percona_telemetry v1.0.0
+      description: What version of PostgreSQL and percona_pg_telemetry are you running?
+      placeholder: PostgreSQL 16.2, percona_pg_telemetry v1.0.0
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for suggesting an idea to make pg_percona_telemetry better! Please complete the below form to ensure we have all the details to get things started.
+        Thank you for suggesting an idea to make percona_pg_telemetry better! Please complete the below form to ensure we have all the details to get things started.
   - type: textarea
     id: description
     attributes:

--- a/.github/workflows/postgresql-12-build.yml
+++ b/.github/workflows/postgresql-12-build.yml
@@ -41,21 +41,21 @@ jobs:
            make -j4
         working-directory: postgres
 
-      - name: Clone percona_telemetry repository
+      - name: Clone percona_pg_telemetry repository
         uses: actions/checkout@v4
         with:
-          path: 'postgres/contrib/percona_telemetry'
+          path: 'postgres/contrib/percona_pg_telemetry'
 
-      - name: Build percona_telemetry
+      - name: Build percona_pg_telemetry
         run: |
           make
           sudo make install
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
-      - name: Run percona_telemetry regression
+      - name: Run percona_pg_telemetry regression
         run: |
           PT_DEBUG=1 make check
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
       - name: Upload logs on fail
         if: ${{ failure() }}
@@ -63,16 +63,16 @@ jobs:
         with:
           name: Regressions diff and postgresql log
           path: |
-            postgres/contrib/percona_telemetry/regression.diffs
-            postgres/contrib/percona_telemetry/regression.out
-            postgres/contrib/percona_telemetry/logfile
-            postgres/contrib/percona_telemetry/t/results/
-            postgres/contrib/percona_telemetry/tmp_check/log/
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/
+            postgres/contrib/percona_pg_telemetry/regression.diffs
+            postgres/contrib/percona_pg_telemetry/regression.out
+            postgres/contrib/percona_pg_telemetry/logfile
+            postgres/contrib/percona_pg_telemetry/t/results/
+            postgres/contrib/percona_pg_telemetry/tmp_check/log/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/
           if-no-files-found: warn
           retention-days: 3

--- a/.github/workflows/postgresql-13-build.yml
+++ b/.github/workflows/postgresql-13-build.yml
@@ -41,21 +41,21 @@ jobs:
            make -j4
         working-directory: postgres
 
-      - name: Clone percona_telemetry repository
+      - name: Clone percona_pg_telemetry repository
         uses: actions/checkout@v4
         with:
-          path: 'postgres/contrib/percona_telemetry'
+          path: 'postgres/contrib/percona_pg_telemetry'
 
-      - name: Build percona_telemetry
+      - name: Build percona_pg_telemetry
         run: |
           make
           sudo make install
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
-      - name: Run percona_telemetry regression
+      - name: Run percona_pg_telemetry regression
         run: |
           PT_DEBUG=1 make check
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
       - name: Upload logs on fail
         if: ${{ failure() }}
@@ -63,16 +63,16 @@ jobs:
         with:
           name: Regressions diff and postgresql log
           path: |
-            postgres/contrib/percona_telemetry/regression.diffs
-            postgres/contrib/percona_telemetry/regression.out
-            postgres/contrib/percona_telemetry/logfile
-            postgres/contrib/percona_telemetry/t/results/
-            postgres/contrib/percona_telemetry/tmp_check/log/
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/
+            postgres/contrib/percona_pg_telemetry/regression.diffs
+            postgres/contrib/percona_pg_telemetry/regression.out
+            postgres/contrib/percona_pg_telemetry/logfile
+            postgres/contrib/percona_pg_telemetry/t/results/
+            postgres/contrib/percona_pg_telemetry/tmp_check/log/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/
           if-no-files-found: warn
           retention-days: 3

--- a/.github/workflows/postgresql-14-build.yml
+++ b/.github/workflows/postgresql-14-build.yml
@@ -41,21 +41,21 @@ jobs:
            make -j4
         working-directory: postgres
 
-      - name: Clone percona_telemetry repository
+      - name: Clone percona_pg_telemetry repository
         uses: actions/checkout@v4
         with:
-          path: 'postgres/contrib/percona_telemetry'
+          path: 'postgres/contrib/percona_pg_telemetry'
 
-      - name: Build percona_telemetry
+      - name: Build percona_pg_telemetry
         run: |
           make
           sudo make install
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
-      - name: Run percona_telemetry regression
+      - name: Run percona_pg_telemetry regression
         run: |
           PT_DEBUG=1 make check
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
       - name: Upload logs on fail
         if: ${{ failure() }}
@@ -63,16 +63,16 @@ jobs:
         with:
           name: Regressions diff and postgresql log
           path: |
-            postgres/contrib/percona_telemetry/regression.diffs
-            postgres/contrib/percona_telemetry/regression.out
-            postgres/contrib/percona_telemetry/logfile
-            postgres/contrib/percona_telemetry/t/results/
-            postgres/contrib/percona_telemetry/tmp_check/log/
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/
+            postgres/contrib/percona_pg_telemetry/regression.diffs
+            postgres/contrib/percona_pg_telemetry/regression.out
+            postgres/contrib/percona_pg_telemetry/logfile
+            postgres/contrib/percona_pg_telemetry/t/results/
+            postgres/contrib/percona_pg_telemetry/tmp_check/log/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/
           if-no-files-found: warn
           retention-days: 3

--- a/.github/workflows/postgresql-15-build.yml
+++ b/.github/workflows/postgresql-15-build.yml
@@ -41,21 +41,21 @@ jobs:
            make -j4
         working-directory: postgres
 
-      - name: Clone percona_telemetry repository
+      - name: Clone percona_pg_telemetry repository
         uses: actions/checkout@v4
         with:
-          path: 'postgres/contrib/percona_telemetry'
+          path: 'postgres/contrib/percona_pg_telemetry'
 
-      - name: Build percona_telemetry
+      - name: Build percona_pg_telemetry
         run: |
           make
           sudo make install
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
-      - name: Run percona_telemetry regression
+      - name: Run percona_pg_telemetry regression
         run: |
           PT_DEBUG=1 make check
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
       - name: Upload logs on fail
         if: ${{ failure() }}
@@ -63,16 +63,16 @@ jobs:
         with:
           name: Regressions diff and postgresql log
           path: |
-            postgres/contrib/percona_telemetry/regression.diffs
-            postgres/contrib/percona_telemetry/regression.out
-            postgres/contrib/percona_telemetry/logfile
-            postgres/contrib/percona_telemetry/t/results/
-            postgres/contrib/percona_telemetry/tmp_check/log/
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/
+            postgres/contrib/percona_pg_telemetry/regression.diffs
+            postgres/contrib/percona_pg_telemetry/regression.out
+            postgres/contrib/percona_pg_telemetry/logfile
+            postgres/contrib/percona_pg_telemetry/t/results/
+            postgres/contrib/percona_pg_telemetry/tmp_check/log/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/
           if-no-files-found: warn
           retention-days: 3

--- a/.github/workflows/postgresql-16-build.yml
+++ b/.github/workflows/postgresql-16-build.yml
@@ -41,21 +41,21 @@ jobs:
            make -j4
         working-directory: postgres
 
-      - name: Clone percona_telemetry repository
+      - name: Clone percona_pg_telemetry repository
         uses: actions/checkout@v4
         with:
-          path: 'postgres/contrib/percona_telemetry'
+          path: 'postgres/contrib/percona_pg_telemetry'
 
-      - name: Build percona_telemetry
+      - name: Build percona_pg_telemetry
         run: |
           make
           sudo make install
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
-      - name: Run percona_telemetry regression
+      - name: Run percona_pg_telemetry regression
         run: |
           PT_DEBUG=1 make check
-        working-directory: postgres/contrib/percona_telemetry
+        working-directory: postgres/contrib/percona_pg_telemetry
 
       - name: Upload logs on fail
         if: ${{ failure() }}
@@ -63,16 +63,16 @@ jobs:
         with:
           name: Regressions diff and postgresql log
           path: |
-            postgres/contrib/percona_telemetry/regression.diffs
-            postgres/contrib/percona_telemetry/regression.out
-            postgres/contrib/percona_telemetry/logfile
-            postgres/contrib/percona_telemetry/t/results/
-            postgres/contrib/percona_telemetry/tmp_check/log/
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/*
-            !postgres/contrib/percona_telemetry/tmp_check/**/archives/
-            !postgres/contrib/percona_telemetry/tmp_check/**/backup/
-            !postgres/contrib/percona_telemetry/tmp_check/**/pgdata/
+            postgres/contrib/percona_pg_telemetry/regression.diffs
+            postgres/contrib/percona_pg_telemetry/regression.out
+            postgres/contrib/percona_pg_telemetry/logfile
+            postgres/contrib/percona_pg_telemetry/t/results/
+            postgres/contrib/percona_pg_telemetry/tmp_check/log/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/*
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/archives/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/backup/
+            !postgres/contrib/percona_pg_telemetry/tmp_check/**/pgdata/
           if-no-files-found: warn
           retention-days: 3

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
-# contrib/percona_telemetry/Makefile
+# contrib/percona_pg_telemetry/Makefile
 
-MODULE_big = percona_telemetry
+MODULE_big = percona_pg_telemetry
 OBJS = \
 	$(WIN32RES) \
 	pt_json.o	\
-	percona_telemetry.o
+	percona_pg_telemetry.o
 
-EXTENSION = percona_telemetry
-DATA = percona_telemetry--1.0.sql
+EXTENSION = percona_pg_telemetry
+DATA = percona_pg_telemetry--1.0.sql
 
-PGFILEDESC = "percona_telemetry - extension for Percona telemetry data collection."
+PGFILEDESC = "percona_pg_telemetry - extension for Percona telemetry data collection."
 
-REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/percona_telemetry/percona_telemetry.conf
+REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/percona_pg_telemetry/percona_pg_telemetry.conf
 REGRESS = basic debug_json gucs
 
 ifdef USE_PGXS
@@ -19,7 +19,7 @@ PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 else
-subdir = contrib/percona_telemetry
+subdir = contrib/percona_pg_telemetry
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![postgresql-12-build](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-12-build.yml/badge.svg)](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-12-build.yml)  [![postgresql-13-build](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-13-build.yml/badge.svg)](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-13-build.yml)  [![postgresql-14-build](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-14-build.yml/badge.svg)](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-14-build.yml)  [![postgresql-15-build](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-15-build.yml/badge.svg)](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-15-build.yml)  [![postgresql-16-build](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-16-build.yml/badge.svg)](https://github.com/Percona-Lab/pg_percona_telemetry/actions/workflows/postgresql-16-build.yml)
+[![postgresql-12-build](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-12-build.yml/badge.svg)](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-12-build.yml)  [![postgresql-13-build](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-13-build.yml/badge.svg)](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-13-build.yml)  [![postgresql-14-build](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-14-build.yml/badge.svg)](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-14-build.yml)  [![postgresql-15-build](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-15-build.yml/badge.svg)](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-15-build.yml)  [![postgresql-16-build](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-16-build.yml/badge.svg)](https://github.com/Percona-Lab/percona_pg_telemetry/actions/workflows/postgresql-16-build.yml)
 
 # Percona Telemetry Extension for PostgreSQL
 
-Welcome to `percona_telemetry` - extension for Percona telemetry data collection for PostgreSQL!
+Welcome to `percona_pg_telemetry` - extension for Percona telemetry data collection for PostgreSQL!
 
 ## Overview
 
@@ -10,21 +10,21 @@ The extenions it be provided with the Percona distribution. The extension, at no
 
 ### Configuration
 
-You can find the configuration parameters of the `percona_telemetry` extension in the `pg_settings` view by filtering `name` column with `percona_telemetry` prefix. To change the default configuration, specify new values for the desired parameters using the GUC (Grand Unified Configuration) system. Alternatively, values may be changed by a superuser either at the server start time or via `ALTER SYSTEM` command followed `SELECT pg_reload_conf();` statement.
+You can find the configuration parameters of the `percona_pg_telemetry` extension in the `pg_settings` view by filtering `name` column with `percona_pg_telemetry` prefix. To change the default configuration, specify new values for the desired parameters using the GUC (Grand Unified Configuration) system. Alternatively, values may be changed by a superuser either at the server start time or via `ALTER SYSTEM` command followed `SELECT pg_reload_conf();` statement.
 
 #### Parameters
 
-1. `percona_telemetry.enabled`
+1. `percona_pg_telemetry.enabled`
 
   * Default: true
   * Unit: boolean
   * When set to `false`, the leader process terminates when the configuration is read.
 
-2. `percona_telemetry.pg_telemetry_folder`
+2. `percona_pg_telemetry.pg_telemetry_folder`
 
   * Default: /usr/local/percona/telemetry/pg
 
-3. `percona_telemetry.scrape_interval`
+3. `percona_pg_telemetry.scrape_interval`
 
   * Default: 86,400 (24 hours)
   * Unit: s
@@ -32,7 +32,7 @@ You can find the configuration parameters of the `percona_telemetry` extension i
     may be woken up by a configuration reload interrupt or when the shutdown process is
     initiated.
 
-4. `percona_telemetry.files_to_keep`
+4. `percona_pg_telemetry.files_to_keep`
 
   * Default: 7
   * Unit: Integer
@@ -43,11 +43,11 @@ You can find the configuration parameters of the `percona_telemetry` extension i
 
 #### Functions
 
-1. `percona_telemetry_version()`
+1. `percona_pg_telemetry_version()`
 
   * Outputs the version of the extension.
 
-2. `percona_telemetry_status`
+2. `percona_pg_telemetry_status`
 
   * OUT: latest_output_filename   - TEXT
     - Path of the JSON output file.
@@ -56,14 +56,14 @@ You can find the configuration parameters of the `percona_telemetry` extension i
 
 ### Setup
 
-You can enable `percona_telemetry` when your `postgresql` instance is not running.
+You can enable `percona_pg_telemetry` when your `postgresql` instance is not running.
 
-`percona_telemetry` needs to be loaded at the start time. The extension requires additional shared memory; therefore,  add the `percona_telemetry` value for the `shared_preload_libraries` parameter and restart the `postgresql` instance.
+`percona_pg_telemetry` needs to be loaded at the start time. The extension requires additional shared memory; therefore,  add the `percona_pg_telemetry` value for the `shared_preload_libraries` parameter and restart the `postgresql` instance.
 
 Use the [ALTER SYSTEM](https://www.postgresql.org/docs/current/sql-altersystem.html) command from `psql` terminal to modify the `shared_preload_libraries` parameter.
 
 ```sql
-ALTER SYSTEM SET shared_preload_libraries = 'percona_telemetry';
+ALTER SYSTEM SET shared_preload_libraries = 'percona_pg_telemetry';
 ```
 
 > **NOTE**: If you’ve added other modules to the `shared_preload_libraries` parameter (for example, `pg_stat_monitor`), list all of them separated by commas for the `ALTER SYSTEM` command.
@@ -74,17 +74,17 @@ Create the extension using the [CREATE EXTENSION](https://www.postgresql.org/doc
 
 
 ```sql
-CREATE EXTENSION percona_telemetry;
+CREATE EXTENSION percona_pg_telemetry;
 ```
 
 
-This allows you to see the stats collected by `percona_telemetry`.
+This allows you to see the stats collected by `percona_pg_telemetry`.
 
-By default, `percona_telemetry` is created for the `postgres` database. To access its functions in other databases, you need to create the extension for every required database.
+By default, `percona_pg_telemetry` is created for the `postgres` database. To access its functions in other databases, you need to create the extension for every required database.
 
 ### Building from source
 
-To build `percona_telemetry` from source code, you require the following:
+To build `percona_pg_telemetry` from source code, you require the following:
 
 * git
 * make
@@ -92,16 +92,16 @@ To build `percona_telemetry` from source code, you require the following:
 * postgresql-devel | postgresql-server-dev-all
 
 
-You can download the source code of the latest release of `percona_telemetry` from [the releases page on GitHub](https://github.com/Percona-Lab/pg_percona_telemetry/releases) or using git:
+You can download the source code of the latest release of `percona_pg_telemetry` from [the releases page on GitHub](https://github.com/Percona-Lab/percona_pg_telemetry/releases) or using git:
 
 ```
-git clone git://github.com/Percona-Lab/pg_percona_telemetry.git
+git clone git://github.com/Percona-Lab/percona_pg_telemetry.git
 ```
 
 Compile and install the extension
 
 ```
-cd percona_telemetry
+cd percona_pg_telemetry
 make
 make install
 ```
@@ -112,25 +112,25 @@ To run the associated regression tests, a make target is available. ```make inst
 make check
 ```
 
-### Uninstall `percona_telemetry`
+### Uninstall `percona_pg_telemetry`
 
-To uninstall `percona_telemetry`, do the following:
+To uninstall `percona_pg_telemetry`, do the following:
 
 1. Disable telemetry data collection. From the `psql` terminal or another similar client, run the following command:
 
     ```sql
-    ALTER SYSTEM SET percona_telemetry.enabled = 0;
+    ALTER SYSTEM SET percona_pg_telemetry.enabled = 0;
     SELECT pg_reload_conf();
     ```
-**NOTE**: This will cause the leader process to exit. To restart the leader process, ensure that `percona_telemetry.enabled = 1`, and then restart the database server process.
+**NOTE**: This will cause the leader process to exit. To restart the leader process, ensure that `percona_pg_telemetry.enabled = 1`, and then restart the database server process.
 
-2. Drop `percona_telemetry` extension:
+2. Drop `percona_pg_telemetry` extension:
 
     ```sql
-    DROP EXTENSION percona_telemetry;
+    DROP EXTENSION percona_pg_telemetry;
     ```
 
-3. Remove `percona_telemetry` from the `shared_preload_libraries` configuration parameter:
+3. Remove `percona_pg_telemetry` from the `shared_preload_libraries` configuration parameter:
 
     ```sql
     ALTER SYSTEM SET shared_preload_libraries = '';

--- a/expected/basic.out
+++ b/expected/basic.out
@@ -12,8 +12,8 @@ SELECT  pg_sleep(3);
 SELECT  name
 FROM    pg_settings
 WHERE   name LIKE 'percona_pg_telemetry.%';
-                 name                  
----------------------------------------
+                   name                   
+------------------------------------------
  percona_pg_telemetry.enabled
  percona_pg_telemetry.files_to_keep
  percona_pg_telemetry.pg_telemetry_folder
@@ -22,15 +22,15 @@ WHERE   name LIKE 'percona_pg_telemetry.%';
 
 SELECT  percona_pg_telemetry_version();
  percona_pg_telemetry_version 
----------------------------
+------------------------------
  1.0
 (1 row)
 
 SELECT  regexp_replace(regexp_replace(latest_output_filename, '\d{11,}', '<INSTANCE ID>', 'g'), '\d{6,}', '<TIMESTAMP>', 'g') AS latest_output_filename
         , pt_enabled
 FROM    percona_pg_telemetry_status();
-               latest_output_filename               | pt_enabled 
-----------------------------------------------------+------------
+                latest_output_filename                 | pt_enabled 
+-------------------------------------------------------+------------
  ./percona_pg_telemetry-<INSTANCE ID>-<TIMESTAMP>.json | t
 (1 row)
 

--- a/expected/basic.out
+++ b/expected/basic.out
@@ -1,7 +1,7 @@
 --
 -- basic sanity
 --
-CREATE  EXTENSION percona_telemetry;
+CREATE  EXTENSION percona_pg_telemetry;
 -- Sleep so that waiting on agent becomes true
 SELECT  pg_sleep(3);
  pg_sleep 
@@ -11,27 +11,27 @@ SELECT  pg_sleep(3);
 
 SELECT  name
 FROM    pg_settings
-WHERE   name LIKE 'percona_telemetry.%';
+WHERE   name LIKE 'percona_pg_telemetry.%';
                  name                  
 ---------------------------------------
- percona_telemetry.enabled
- percona_telemetry.files_to_keep
- percona_telemetry.pg_telemetry_folder
- percona_telemetry.scrape_interval
+ percona_pg_telemetry.enabled
+ percona_pg_telemetry.files_to_keep
+ percona_pg_telemetry.pg_telemetry_folder
+ percona_pg_telemetry.scrape_interval
 (4 rows)
 
-SELECT  percona_telemetry_version();
- percona_telemetry_version 
+SELECT  percona_pg_telemetry_version();
+ percona_pg_telemetry_version 
 ---------------------------
  1.0
 (1 row)
 
 SELECT  regexp_replace(regexp_replace(latest_output_filename, '\d{11,}', '<INSTANCE ID>', 'g'), '\d{6,}', '<TIMESTAMP>', 'g') AS latest_output_filename
         , pt_enabled
-FROM    percona_telemetry_status();
+FROM    percona_pg_telemetry_status();
                latest_output_filename               | pt_enabled 
 ----------------------------------------------------+------------
- ./percona_telemetry-<INSTANCE ID>-<TIMESTAMP>.json | t
+ ./percona_pg_telemetry-<INSTANCE ID>-<TIMESTAMP>.json | t
 (1 row)
 
-DROP    EXTENSION percona_telemetry;
+DROP    EXTENSION percona_pg_telemetry;

--- a/expected/basic_1.out
+++ b/expected/basic_1.out
@@ -12,22 +12,22 @@ SELECT  pg_sleep(3);
 SELECT  name
 FROM    pg_settings
 WHERE   name LIKE 'percona_pg_telemetry.%';
-           name            
----------------------------
+             name             
+------------------------------
  percona_pg_telemetry.enabled
 (1 row)
 
 SELECT  percona_pg_telemetry_version();
  percona_pg_telemetry_version 
----------------------------
+------------------------------
  1.0
 (1 row)
 
 SELECT  regexp_replace(regexp_replace(latest_output_filename, '\d{11,}', '<INSTANCE ID>', 'g'), '\d{6,}', '<TIMESTAMP>', 'g') AS latest_output_filename
         , pt_enabled
 FROM    percona_pg_telemetry_status();
-                              latest_output_filename                              | pt_enabled 
-----------------------------------------------------------------------------------+------------
+                               latest_output_filename                                | pt_enabled 
+-------------------------------------------------------------------------------------+------------
  /usr/local/percona/telemetry/pg/percona_pg_telemetry-<INSTANCE ID>-<TIMESTAMP>.json | t
 (1 row)
 

--- a/expected/basic_1.out
+++ b/expected/basic_1.out
@@ -1,7 +1,7 @@
 --
 -- basic sanity
 --
-CREATE  EXTENSION percona_telemetry;
+CREATE  EXTENSION percona_pg_telemetry;
 -- Sleep so that waiting on agent becomes true
 SELECT  pg_sleep(3);
  pg_sleep 
@@ -11,24 +11,24 @@ SELECT  pg_sleep(3);
 
 SELECT  name
 FROM    pg_settings
-WHERE   name LIKE 'percona_telemetry.%';
+WHERE   name LIKE 'percona_pg_telemetry.%';
            name            
 ---------------------------
- percona_telemetry.enabled
+ percona_pg_telemetry.enabled
 (1 row)
 
-SELECT  percona_telemetry_version();
- percona_telemetry_version 
+SELECT  percona_pg_telemetry_version();
+ percona_pg_telemetry_version 
 ---------------------------
  1.0
 (1 row)
 
 SELECT  regexp_replace(regexp_replace(latest_output_filename, '\d{11,}', '<INSTANCE ID>', 'g'), '\d{6,}', '<TIMESTAMP>', 'g') AS latest_output_filename
         , pt_enabled
-FROM    percona_telemetry_status();
+FROM    percona_pg_telemetry_status();
                               latest_output_filename                              | pt_enabled 
 ----------------------------------------------------------------------------------+------------
- /usr/local/percona/telemetry/pg/percona_telemetry-<INSTANCE ID>-<TIMESTAMP>.json | t
+ /usr/local/percona/telemetry/pg/percona_pg_telemetry-<INSTANCE ID>-<TIMESTAMP>.json | t
 (1 row)
 
-DROP    EXTENSION percona_telemetry;
+DROP    EXTENSION percona_pg_telemetry;

--- a/expected/debug_json.out
+++ b/expected/debug_json.out
@@ -10,7 +10,7 @@ DECLARE
     pg_version text;
     file_content text;
 BEGIN
-    SELECT latest_output_filename INTO file_path FROM percona_telemetry_status();
+    SELECT latest_output_filename INTO file_path FROM percona_pg_telemetry_status();
     SELECT system_identifier::TEXT INTO system_id FROM pg_control_system();
     SELECT version() INTO pg_version;
 
@@ -27,7 +27,7 @@ SELECT pg_sleep(3);
  
 (1 row)
 
-CREATE EXTENSION percona_telemetry;
+CREATE EXTENSION percona_pg_telemetry;
 SELECT  'matches' AS db_instance_id
 FROM    pg_control_system()
 WHERE   '"' || system_identifier || '"' = (SELECT CAST(read_json_file()::JSON->'db_instance_id' AS VARCHAR));
@@ -84,5 +84,5 @@ HAVING  COUNT(*) = (
 (1 row)
 
 -- Databases count will fail if you have any preexisting databases other than the standard template1 and postgres
-DROP EXTENSION percona_telemetry;
+DROP EXTENSION percona_pg_telemetry;
 DROP FUNCTION read_json_file;

--- a/expected/gucs.out
+++ b/expected/gucs.out
@@ -1,31 +1,31 @@
 --
 -- GUC sanity
 --
-CREATE EXTENSION percona_telemetry;
+CREATE EXTENSION percona_pg_telemetry;
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
-WHERE application_name = 'percona_telemetry';
+WHERE application_name = 'percona_pg_telemetry';
  application_name  |        backend_type        | backend_started 
 -------------------+----------------------------+-----------------
- percona_telemetry | percona_telemetry launcher | t
+ percona_pg_telemetry | percona_pg_telemetry launcher | t
 (1 row)
 
 \x
 SELECT name, setting, unit, short_desc, min_val, max_val, boot_val, reset_val
 FROM pg_settings
-WHERE name LIKE 'percona_telemetry.%'
+WHERE name LIKE 'percona_pg_telemetry.%'
 ORDER BY name;
 -[ RECORD 1 ]-------------------------------------------------
-name       | percona_telemetry.enabled
+name       | percona_pg_telemetry.enabled
 setting    | on
 unit       | 
-short_desc | Enable or disable the percona_telemetry extension
+short_desc | Enable or disable the percona_pg_telemetry extension
 min_val    | 
 max_val    | 
 boot_val   | on
 reset_val  | on
 -[ RECORD 2 ]-------------------------------------------------
-name       | percona_telemetry.files_to_keep
+name       | percona_pg_telemetry.files_to_keep
 setting    | 7
 unit       | 
 short_desc | Number of JSON files to keep for this instance.
@@ -34,7 +34,7 @@ max_val    | 100
 boot_val   | 7
 reset_val  | 7
 -[ RECORD 3 ]-------------------------------------------------
-name       | percona_telemetry.pg_telemetry_folder
+name       | percona_pg_telemetry.pg_telemetry_folder
 setting    | .
 unit       | 
 short_desc | Directory path for writing database info file(s)
@@ -43,7 +43,7 @@ max_val    |
 boot_val   | /usr/local/percona/telemetry/pg
 reset_val  | .
 -[ RECORD 4 ]-------------------------------------------------
-name       | percona_telemetry.scrape_interval
+name       | percona_pg_telemetry.scrape_interval
 setting    | 1
 unit       | s
 short_desc | Data scrape interval
@@ -53,7 +53,7 @@ boot_val   | 86400
 reset_val  | 1
 
 \x
-ALTER SYSTEM SET percona_telemetry.enabled = false;
+ALTER SYSTEM SET percona_pg_telemetry.enabled = false;
 SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------
@@ -68,17 +68,17 @@ SELECT pg_sleep(2);
 
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
-WHERE application_name = 'percona_telemetry';
+WHERE application_name = 'percona_pg_telemetry';
  application_name  |        backend_type        | backend_started 
 -------------------+----------------------------+-----------------
- percona_telemetry | percona_telemetry launcher | t
+ percona_pg_telemetry | percona_pg_telemetry launcher | t
 (1 row)
 
-ALTER SYSTEM RESET percona_telemetry.enabled;
+ALTER SYSTEM RESET percona_pg_telemetry.enabled;
 SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------
  t
 (1 row)
 
-DROP EXTENSION percona_telemetry;
+DROP EXTENSION percona_pg_telemetry;

--- a/expected/gucs.out
+++ b/expected/gucs.out
@@ -5,8 +5,8 @@ CREATE EXTENSION percona_pg_telemetry;
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
 WHERE application_name = 'percona_pg_telemetry';
- application_name  |        backend_type        | backend_started 
--------------------+----------------------------+-----------------
+   application_name   |         backend_type          | backend_started 
+----------------------+-------------------------------+-----------------
  percona_pg_telemetry | percona_pg_telemetry launcher | t
 (1 row)
 
@@ -15,7 +15,7 @@ SELECT name, setting, unit, short_desc, min_val, max_val, boot_val, reset_val
 FROM pg_settings
 WHERE name LIKE 'percona_pg_telemetry.%'
 ORDER BY name;
--[ RECORD 1 ]-------------------------------------------------
+-[ RECORD 1 ]----------------------------------------------------
 name       | percona_pg_telemetry.enabled
 setting    | on
 unit       | 
@@ -24,7 +24,7 @@ min_val    |
 max_val    | 
 boot_val   | on
 reset_val  | on
--[ RECORD 2 ]-------------------------------------------------
+-[ RECORD 2 ]----------------------------------------------------
 name       | percona_pg_telemetry.files_to_keep
 setting    | 7
 unit       | 
@@ -33,7 +33,7 @@ min_val    | 1
 max_val    | 100
 boot_val   | 7
 reset_val  | 7
--[ RECORD 3 ]-------------------------------------------------
+-[ RECORD 3 ]----------------------------------------------------
 name       | percona_pg_telemetry.pg_telemetry_folder
 setting    | .
 unit       | 
@@ -42,7 +42,7 @@ min_val    |
 max_val    | 
 boot_val   | /usr/local/percona/telemetry/pg
 reset_val  | .
--[ RECORD 4 ]-------------------------------------------------
+-[ RECORD 4 ]----------------------------------------------------
 name       | percona_pg_telemetry.scrape_interval
 setting    | 1
 unit       | s
@@ -69,8 +69,8 @@ SELECT pg_sleep(2);
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
 WHERE application_name = 'percona_pg_telemetry';
- application_name  |        backend_type        | backend_started 
--------------------+----------------------------+-----------------
+   application_name   |         backend_type          | backend_started 
+----------------------+-------------------------------+-----------------
  percona_pg_telemetry | percona_pg_telemetry launcher | t
 (1 row)
 

--- a/expected/gucs_1.out
+++ b/expected/gucs_1.out
@@ -1,32 +1,32 @@
 --
 -- GUC sanity
 --
-CREATE EXTENSION percona_telemetry;
+CREATE EXTENSION percona_pg_telemetry;
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
-WHERE application_name = 'percona_telemetry';
+WHERE application_name = 'percona_pg_telemetry';
  application_name  |        backend_type        | backend_started 
 -------------------+----------------------------+-----------------
- percona_telemetry | percona_telemetry launcher | t
+ percona_pg_telemetry | percona_pg_telemetry launcher | t
 (1 row)
 
 \x
 SELECT name, setting, unit, short_desc, min_val, max_val, boot_val, reset_val
 FROM pg_settings
-WHERE name LIKE 'percona_telemetry.%'
+WHERE name LIKE 'percona_pg_telemetry.%'
 ORDER BY name;
 -[ RECORD 1 ]-------------------------------------------------
-name       | percona_telemetry.enabled
+name       | percona_pg_telemetry.enabled
 setting    | on
 unit       | 
-short_desc | Enable or disable the percona_telemetry extension
+short_desc | Enable or disable the percona_pg_telemetry extension
 min_val    | 
 max_val    | 
 boot_val   | on
 reset_val  | on
 
 \x
-ALTER SYSTEM SET percona_telemetry.enabled = false;
+ALTER SYSTEM SET percona_pg_telemetry.enabled = false;
 SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------
@@ -41,17 +41,17 @@ SELECT pg_sleep(2);
 
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
-WHERE application_name = 'percona_telemetry';
+WHERE application_name = 'percona_pg_telemetry';
  application_name  |        backend_type        | backend_started 
 -------------------+----------------------------+-----------------
- percona_telemetry | percona_telemetry launcher | t
+ percona_pg_telemetry | percona_pg_telemetry launcher | t
 (1 row)
 
-ALTER SYSTEM RESET percona_telemetry.enabled;
+ALTER SYSTEM RESET percona_pg_telemetry.enabled;
 SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------
  t
 (1 row)
 
-DROP EXTENSION percona_telemetry;
+DROP EXTENSION percona_pg_telemetry;

--- a/expected/gucs_1.out
+++ b/expected/gucs_1.out
@@ -5,8 +5,8 @@ CREATE EXTENSION percona_pg_telemetry;
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
 WHERE application_name = 'percona_pg_telemetry';
- application_name  |        backend_type        | backend_started 
--------------------+----------------------------+-----------------
+   application_name   |         backend_type          | backend_started 
+----------------------+-------------------------------+-----------------
  percona_pg_telemetry | percona_pg_telemetry launcher | t
 (1 row)
 
@@ -15,7 +15,7 @@ SELECT name, setting, unit, short_desc, min_val, max_val, boot_val, reset_val
 FROM pg_settings
 WHERE name LIKE 'percona_pg_telemetry.%'
 ORDER BY name;
--[ RECORD 1 ]-------------------------------------------------
+-[ RECORD 1 ]----------------------------------------------------
 name       | percona_pg_telemetry.enabled
 setting    | on
 unit       | 
@@ -42,8 +42,8 @@ SELECT pg_sleep(2);
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
 WHERE application_name = 'percona_pg_telemetry';
- application_name  |        backend_type        | backend_started 
--------------------+----------------------------+-----------------
+   application_name   |         backend_type          | backend_started 
+----------------------+-------------------------------+-----------------
  percona_pg_telemetry | percona_pg_telemetry launcher | t
 (1 row)
 

--- a/meson.build
+++ b/meson.build
@@ -1,30 +1,30 @@
-percona_telemetry_sources = files(
+percona_pg_telemetry_sources = files(
   'pt_json.c',
-  'percona_telemetry.c',
+  'percona_pg_telemetry.c',
 )
 
 if host_system == 'windows'
-  percona_telemetry_sources += rc_lib_gen.process(win32ver_rc, extra_args: [
-    '--NAME', 'percona_telemetry',
-    '--FILEDESC', 'percona_telemetry - extension for Percona telemetry data collection',])
+  percona_pg_telemetry_sources += rc_lib_gen.process(win32ver_rc, extra_args: [
+    '--NAME', 'percona_pg_telemetry',
+    '--FILEDESC', 'percona_pg_telemetry - extension for Percona telemetry data collection',])
 endif
 
-percona_telemetry = shared_module('percona_telemetry',
-  percona_telemetry_sources,
+percona_pg_telemetry = shared_module('percona_pg_telemetry',
+  percona_pg_telemetry_sources,
   kwargs: contrib_mod_args + {
     'dependencies': contrib_mod_args['dependencies'],
   },
 )
-contrib_targets += percona_telemetry
+contrib_targets += percona_pg_telemetry
 
 install_data(
-  'percona_telemetry.control',
-  'percona_telemetry--1.0.sql',
+  'percona_pg_telemetry.control',
+  'percona_pg_telemetry--1.0.sql',
   kwargs: contrib_data_args,
 )
 
 tests += {
-  'name': 'percona_telemetry',
+  'name': 'percona_pg_telemetry',
   'sd': meson.current_source_dir(),
   'bd': meson.current_build_dir(),
   'regress': {
@@ -33,7 +33,7 @@ tests += {
       'debug_json',
       'gucs',
     ],
-    'regress_args': ['--temp-config', files('percona_telemetry.conf')],
+    'regress_args': ['--temp-config', files('percona_pg_telemetry.conf')],
 
 # Disabled because these regression tests require the lib to be added to
 # shared preload libraries, which typical installcheck users do not have.

--- a/percona_pg_telemetry--1.0.sql
+++ b/percona_pg_telemetry--1.0.sql
@@ -1,11 +1,11 @@
--- percona_telemetry--1.0.sql
+-- percona_pg_telemetry--1.0.sql
 
-CREATE FUNCTION percona_telemetry_version()
+CREATE FUNCTION percona_pg_telemetry_version()
 RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C PARALLEL SAFE;
 
-CREATE FUNCTION percona_telemetry_status(
+CREATE FUNCTION percona_pg_telemetry_status(
     OUT latest_output_filename  text,
     OUT pt_enabled              boolean)
 RETURNS record

--- a/percona_pg_telemetry.c
+++ b/percona_pg_telemetry.c
@@ -30,7 +30,7 @@
 #include "utils/syscache.h"
 #include "utils/snapmgr.h"
 
-#include "percona_telemetry.h"
+#include "percona_pg_telemetry.h"
 #include "pt_json.h"
 
 #if PG_VERSION_NUM >= 130000
@@ -49,15 +49,15 @@ PG_MODULE_MAGIC;
 
 /* General defines */
 #define PT_BUILD_VERSION    "1.0"
-#define PT_FILENAME_BASE    "percona_telemetry"
+#define PT_FILENAME_BASE    "percona_pg_telemetry"
 
 /* Init and exported functions */
 void _PG_init(void);
-PGDLLEXPORT void percona_telemetry_main(Datum);
-PGDLLEXPORT void percona_telemetry_worker(Datum);
+PGDLLEXPORT void percona_pg_telemetry_main(Datum);
+PGDLLEXPORT void percona_pg_telemetry_worker(Datum);
 
-PG_FUNCTION_INFO_V1(percona_telemetry_status);
-PG_FUNCTION_INFO_V1(percona_telemetry_version);
+PG_FUNCTION_INFO_V1(percona_pg_telemetry_status);
+PG_FUNCTION_INFO_V1(percona_pg_telemetry_version);
 
 
 /* Internal init, shared memeory and signal functions */
@@ -146,7 +146,7 @@ _PG_init(void)
 static void
 start_leader(void)
 {
-    setup_background_worker("percona_telemetry_main", "percona_telemetry launcher", "percona_telemetry launcher", InvalidOid, 0);
+    setup_background_worker("percona_pg_telemetry_main", "percona_pg_telemetry launcher", "percona_pg_telemetry launcher", InvalidOid, 0);
 }
 
 /*
@@ -274,7 +274,7 @@ validate_dir(char *folder_path)
     {
         ereport(LOG,
                 (errcode_for_file_access(),
-                 errmsg("percona_telemetry.pg_telemetry_folder \"%s\" is not set to a writeable folder or the folder does not exist.", folder_path)));
+                 errmsg("percona_pg_telemetry.pg_telemetry_folder \"%s\" is not set to a writeable folder or the folder does not exist.", folder_path)));
 
         PT_WORKER_EXIT(PT_FILE_ERROR);
     }
@@ -283,10 +283,10 @@ validate_dir(char *folder_path)
 }
 
 /*
- * Select the status of percona_telemetry.
+ * Select the status of percona_pg_telemetry.
  */
 Datum
-percona_telemetry_status(PG_FUNCTION_ARGS)
+percona_pg_telemetry_status(PG_FUNCTION_ARGS)
 {
 #define PT_STATUS_COLUMN_COUNT  2
 
@@ -321,10 +321,10 @@ percona_telemetry_status(PG_FUNCTION_ARGS)
 }
 
 /*
- * Select the version of percona_telemetry.
+ * Select the version of percona_pg_telemetry.
  */
 Datum
-percona_telemetry_version(PG_FUNCTION_ARGS)
+percona_pg_telemetry_version(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_TEXT_P(cstring_to_text(PT_BUILD_VERSION));
 }
@@ -353,7 +353,7 @@ pt_shmem_init(void)
 
     LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
 
-    ptss = (PTSharedState *) ShmemInitStruct("percona_telemetry shared state", sizeof(PTSharedState), &found);
+    ptss = (PTSharedState *) ShmemInitStruct("percona_pg_telemetry shared state", sizeof(PTSharedState), &found);
     if (!found)
     {
         uint64 system_id = GetSystemIdentifier();
@@ -385,8 +385,8 @@ init_guc(void)
     char       *env;
 
     /* is the extension enabled? */
-    DefineCustomBoolVariable("percona_telemetry.enabled",
-                             "Enable or disable the percona_telemetry extension",
+    DefineCustomBoolVariable("percona_pg_telemetry.enabled",
+                             "Enable or disable the percona_pg_telemetry extension",
                              NULL,
                              &telemetry_enabled,
                              true,
@@ -400,7 +400,7 @@ init_guc(void)
     if (env != NULL)
     {
         /* file path */
-        DefineCustomStringVariable("percona_telemetry.pg_telemetry_folder",
+        DefineCustomStringVariable("percona_pg_telemetry.pg_telemetry_folder",
                                 "Directory path for writing database info file(s)",
                                 NULL,
                                 &t_folder,
@@ -412,7 +412,7 @@ init_guc(void)
                                 NULL);
 
         /* scan time interval for the main launch process */
-        DefineCustomIntVariable("percona_telemetry.scrape_interval",
+        DefineCustomIntVariable("percona_pg_telemetry.scrape_interval",
                                 "Data scrape interval",
                                 NULL,
                                 &scrape_interval,
@@ -426,7 +426,7 @@ init_guc(void)
                                 NULL);
 
         /* Number of files to keep */
-        DefineCustomIntVariable("percona_telemetry.files_to_keep",
+        DefineCustomIntVariable("percona_pg_telemetry.files_to_keep",
                                 "Number of JSON files to keep for this instance.",
                                 NULL,
                                 &files_to_keep,
@@ -441,7 +441,7 @@ init_guc(void)
     }
 
 #if PG_VERSION_NUM >= 150000
-    MarkGUCPrefixReserved("percona_telemetry");
+    MarkGUCPrefixReserved("percona_pg_telemetry");
 #endif
 }
 
@@ -463,7 +463,7 @@ setup_background_worker(const char *bgw_function_name, const char *bgw_name, con
     worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
     worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
 	worker.bgw_restart_time = BGW_NEVER_RESTART;
-    strcpy(worker.bgw_library_name, "percona_telemetry");
+    strcpy(worker.bgw_library_name, "percona_pg_telemetry");
     strcpy(worker.bgw_function_name, bgw_function_name);
     strcpy(worker.bgw_name, bgw_name);
     strcpy(worker.bgw_type, bgw_type);
@@ -821,7 +821,7 @@ write_database_info(PTDatabaseInfo *dbinfo, List *extlist)
  * Main function for the background launcher process
  */
 void
-percona_telemetry_main(Datum main_arg)
+percona_pg_telemetry_main(Datum main_arg)
 {
 	int rc = 0;
     List *dblist = NIL;
@@ -856,8 +856,8 @@ percona_telemetry_main(Datum main_arg)
     /* Set up connection */
     BackgroundWorkerInitializeConnectionByOid(InvalidOid, InvalidOid, 0);
 
-    /* Set name to make percona_telemetry visible in pg_stat_activity */
-    pgstat_report_appname("percona_telemetry");
+    /* Set name to make percona_pg_telemetry visible in pg_stat_activity */
+    pgstat_report_appname("percona_pg_telemetry");
 
     /* This is the context that we will allocate our data in */
     pt_cxt = AllocSetContextCreate(TopMemoryContext, "Percona Telemetry Context", ALLOCSET_DEFAULT_SIZES);
@@ -999,9 +999,9 @@ percona_telemetry_main(Datum main_arg)
              * Run the dynamic background worker and wait for it's completion
              * so that we can wake up the launcher process.
              */
-        	status = setup_background_worker("percona_telemetry_worker",
-                                                "percona_telemetry worker",
-                                                "percona_telemetry worker",
+        	status = setup_background_worker("percona_pg_telemetry_worker",
+                                                "percona_pg_telemetry worker",
+                                                "percona_pg_telemetry worker",
                                                 ptss->dbinfo.datid, MyProcPid);
 
             /* Wakeup the main process since the worker has stopped. */
@@ -1023,7 +1023,7 @@ percona_telemetry_main(Datum main_arg)
  * Worker process main function
  */
 void
-percona_telemetry_worker(Datum main_arg)
+percona_pg_telemetry_worker(Datum main_arg)
 {
     Oid datid;
     MemoryContext tmpcxt;
@@ -1042,8 +1042,8 @@ percona_telemetry_worker(Datum main_arg)
     /* This is the context that we will allocate our data in */
     tmpcxt = AllocSetContextCreate(TopMemoryContext, "Percona Telemetry Context (tmp)", ALLOCSET_DEFAULT_SIZES);
 
-    /* Set name to make percona_telemetry visible in pg_stat_activity */
-    pgstat_report_appname("percona_telemetry_worker");
+    /* Set name to make percona_pg_telemetry visible in pg_stat_activity */
+    pgstat_report_appname("percona_pg_telemetry_worker");
 
     /* Get the settings */
     if (ptss->first_db_entry)

--- a/percona_pg_telemetry.conf
+++ b/percona_pg_telemetry.conf
@@ -1,0 +1,3 @@
+shared_preload_libraries = 'percona_pg_telemetry'
+percona_pg_telemetry.pg_telemetry_folder = '.'
+percona_pg_telemetry.scrape_interval = 1

--- a/percona_pg_telemetry.control
+++ b/percona_pg_telemetry.control
@@ -1,5 +1,5 @@
 comment = 'Extension for Percona telemetry data collection'
 default_version = '1.0'
-module_pathname = '$libdir/percona_telemetry'
+module_pathname = '$libdir/percona_pg_telemetry'
 relocatable = true
 

--- a/percona_pg_telemetry.h
+++ b/percona_pg_telemetry.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * percona_telemetry.h
+ * percona_pg_telemetry.h
  *      Collect telemetry information for the database cluster.
  *
  * Portions Copyright © 2018-2024, Percona LLC and/or its affiliates
@@ -10,12 +10,12 @@
  * Portions Copyright (c) 1994, The Regents of the University of California
  *
  * IDENTIFICATION
- *    contrib/percona_telemetry/percona_telemetry.h
+ *    contrib/percona_pg_telemetry/percona_pg_telemetry.h
  *
  *-------------------------------------------------------------------------
  */
-#ifndef __PG_PERCONA_TELEMETRY_H__
-#define __PG_PERCONA_TELEMETRY_H__
+#ifndef __PERCONA_PG_TELEMETRY_H__
+#define __PERCONA_PG_TELEMETRY_H__
 
 #include "miscadmin.h"
 #include "access/xact.h"
@@ -78,7 +78,7 @@ typedef struct PTSharedState
     if (IsTransactionBlock())                   \
         CommitTransactionCommand();             \
     if (e_code != PT_SUCCESS)                   \
-        ereport(LOG, (errmsg("percona_telemetry bgworker exiting with error_code = %d", e_code)));    \
+        ereport(LOG, (errmsg("percona_pg_telemetry bgworker exiting with error_code = %d", e_code)));    \
     proc_exit(0);                               \
 }
 

--- a/percona_telemetry.conf
+++ b/percona_telemetry.conf
@@ -1,3 +1,0 @@
-shared_preload_libraries = 'percona_telemetry'
-percona_telemetry.pg_telemetry_folder = '.'
-percona_telemetry.scrape_interval = 1

--- a/pt_json.c
+++ b/pt_json.c
@@ -1,5 +1,5 @@
 #include "pt_json.h"
-#include "percona_telemetry.h"
+#include "percona_pg_telemetry.h"
 
 #include <sys/stat.h>
 

--- a/pt_json.h
+++ b/pt_json.h
@@ -10,7 +10,7 @@
  * Portions Copyright (c) 1994, The Regents of the University of California
  *
  * IDENTIFICATION
- *    contrib/percona_telemetry/pt_json.h
+ *    contrib/percona_pg_telemetry/pt_json.h
  *
  *-------------------------------------------------------------------------
  */

--- a/sample/percona_telemetry.sample.json
+++ b/sample/percona_telemetry.sample.json
@@ -4884,7 +4884,7 @@
                 "value": [
                   {
                     "key": "name",
-                    "value": "percona_telemetry.enabled"
+                    "value": "percona_pg_telemetry.enabled"
                   },
                   {
                     "key": "unit",
@@ -4909,7 +4909,7 @@
                 "value": [
                   {
                     "key": "name",
-                    "value": "percona_telemetry.files_to_keep"
+                    "value": "percona_pg_telemetry.files_to_keep"
                   },
                   {
                     "key": "unit",
@@ -4934,7 +4934,7 @@
                 "value": [
                   {
                     "key": "name",
-                    "value": "percona_telemetry.scrape_interval"
+                    "value": "percona_pg_telemetry.scrape_interval"
                   },
                   {
                     "key": "unit",
@@ -7430,7 +7430,7 @@
                       },
                       {
                         "key": "extension_name",
-                        "value": "percona_telemetry"
+                        "value": "percona_pg_telemetry"
                       }
                     ]
                   }

--- a/sql/basic.sql
+++ b/sql/basic.sql
@@ -2,19 +2,19 @@
 -- basic sanity
 --
 
-CREATE  EXTENSION percona_telemetry;
+CREATE  EXTENSION percona_pg_telemetry;
 
 -- Sleep so that waiting on agent becomes true
 SELECT  pg_sleep(3);
 
 SELECT  name
 FROM    pg_settings
-WHERE   name LIKE 'percona_telemetry.%';
+WHERE   name LIKE 'percona_pg_telemetry.%';
 
-SELECT  percona_telemetry_version();
+SELECT  percona_pg_telemetry_version();
 
 SELECT  regexp_replace(regexp_replace(latest_output_filename, '\d{11,}', '<INSTANCE ID>', 'g'), '\d{6,}', '<TIMESTAMP>', 'g') AS latest_output_filename
         , pt_enabled
-FROM    percona_telemetry_status();
+FROM    percona_pg_telemetry_status();
 
-DROP    EXTENSION percona_telemetry;
+DROP    EXTENSION percona_pg_telemetry;

--- a/sql/debug_json.sql
+++ b/sql/debug_json.sql
@@ -11,7 +11,7 @@ DECLARE
     pg_version text;
     file_content text;
 BEGIN
-    SELECT latest_output_filename INTO file_path FROM percona_telemetry_status();
+    SELECT latest_output_filename INTO file_path FROM percona_pg_telemetry_status();
     SELECT system_identifier::TEXT INTO system_id FROM pg_control_system();
     SELECT version() INTO pg_version;
 
@@ -25,7 +25,7 @@ $$ LANGUAGE plpgsql;
 -- generated the json file.
 SELECT pg_sleep(3);
 
-CREATE EXTENSION percona_telemetry;
+CREATE EXTENSION percona_pg_telemetry;
 
 SELECT  'matches' AS db_instance_id
 FROM    pg_control_system()
@@ -63,5 +63,5 @@ HAVING  COUNT(*) = (
                 );
 -- Databases count will fail if you have any preexisting databases other than the standard template1 and postgres
 
-DROP EXTENSION percona_telemetry;
+DROP EXTENSION percona_pg_telemetry;
 DROP FUNCTION read_json_file;

--- a/sql/gucs.sql
+++ b/sql/gucs.sql
@@ -2,28 +2,28 @@
 -- GUC sanity
 --
 
-CREATE EXTENSION percona_telemetry;
+CREATE EXTENSION percona_pg_telemetry;
 
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
-WHERE application_name = 'percona_telemetry';
+WHERE application_name = 'percona_pg_telemetry';
 
 \x
 SELECT name, setting, unit, short_desc, min_val, max_val, boot_val, reset_val
 FROM pg_settings
-WHERE name LIKE 'percona_telemetry.%'
+WHERE name LIKE 'percona_pg_telemetry.%'
 ORDER BY name;
 \x
 
-ALTER SYSTEM SET percona_telemetry.enabled = false;
+ALTER SYSTEM SET percona_pg_telemetry.enabled = false;
 SELECT pg_reload_conf();
 
 SELECT pg_sleep(2);
 SELECT application_name, backend_type, (backend_start IS NOT NULL) AS backend_started
 FROM pg_stat_activity
-WHERE application_name = 'percona_telemetry';
+WHERE application_name = 'percona_pg_telemetry';
 
-ALTER SYSTEM RESET percona_telemetry.enabled;
+ALTER SYSTEM RESET percona_pg_telemetry.enabled;
 SELECT pg_reload_conf();
 
-DROP EXTENSION percona_telemetry;
+DROP EXTENSION percona_pg_telemetry;


### PR DESCRIPTION
This PR renames the extension from `percona_telemetry` to `percona_pg_telemetery` and all associated resources like functions, parameters, etc...